### PR TITLE
Created shortcuts for snippets - expand, jump next and jump previous

### DIFF
--- a/lua/autoCommands.lua
+++ b/lua/autoCommands.lua
@@ -72,6 +72,15 @@ let g:coc_explorer_global_presets = {
 \ }
 ]]
 
+-- NOTE: This will expand the snippet
+cmd[[
+imap <C-l> <Plug>(coc-snippets-expand)
+]]
+
+cmd[[
+let g:coc_snippet_next = '<c-j>'
+]]
+
 -- NOTE: This is to update Packer and Coc when entering vim
 auto({"VimEnter"}, {
 	pattern = "*",

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -7,6 +7,7 @@ mappings('n', '<c-g>', ':FloatermNew --width=1.0 --height=1.0 --autoclose=2 lazy
 mappings('n', 't', ':TodoTelescope keywords=TODO,PERF,HACK,NOTE,FIX,WARN<CR>')
 mappings('n', '<c-f>', ':JsFixImport<CR>')
 mappings('n', 'm', ':CocCommand explorer --preset floating<CR>')
+mappings('n', 's', ':CocCommand snippets.editSnippets<CR>')
 
 -- Launch panel if nothing is typed after <leader>z
 mappings("n", "<leader>z", "<cmd>Telekasten panel<CR>")


### PR DESCRIPTION
I have created todo-comments snippets

and the shortcuts for jumping forward and  backwards with shortcut keys